### PR TITLE
Prevent minify from generating reserved prefixes in Rust 2021 edition

### DIFF
--- a/rustminify/src/lib.rs
+++ b/rustminify/src/lib.rs
@@ -185,6 +185,14 @@ pub fn minify_tokens(tokens: TokenStream) -> String {
                             *spacing = punct.spacing();
                         }
                     } else {
+                        match &st {
+                            State::AlnumUnderscoreQuote => {
+                                if "#\"'".contains(punct.as_char()) {
+                                    *acc += " ";
+                                }
+                            }
+                            _ => {}
+                        }
                         st = State::PunctChars(
                             punct.as_char().to_string(),
                             cur_pos,

--- a/rustminify/src/lib.rs
+++ b/rustminify/src/lib.rs
@@ -112,8 +112,15 @@ pub fn minify_tokens(tokens: TokenStream) -> String {
                     st = State::None;
                 }
                 TokenTree::Ident(ident) => {
-                    match mem::replace(&mut st, State::AlnumUnderscoreQuote) {
-                        State::AlnumUnderscoreQuote => *acc += " ",
+                    match mem::replace(
+                        &mut st,
+                        if ident.to_string().contains('#') {
+                            State::PoundIdent
+                        } else {
+                            State::AlnumUnderscoreQuote
+                        },
+                    ) {
+                        State::AlnumUnderscoreQuote | State::PoundIdent => *acc += " ",
                         State::PunctChars(puncts, _, _) => *acc += &puncts,
                         _ => {}
                     }
@@ -131,7 +138,7 @@ pub fn minify_tokens(tokens: TokenStream) -> String {
                         (&*literal, State::AlnumUnderscoreQuote)
                     };
                     match mem::replace(&mut st, next) {
-                        State::AlnumUnderscoreQuote => *acc += " ",
+                        State::AlnumUnderscoreQuote | State::PoundIdent => *acc += " ",
                         State::PunctChars(puncts, _, _) => *acc += &puncts,
                         _ => {}
                     }
@@ -214,6 +221,7 @@ pub fn minify_tokens(tokens: TokenStream) -> String {
         enum State {
             None,
             AlnumUnderscoreQuote,
+            PoundIdent,
             PunctChars(String, LineColumn, Spacing),
         }
     }


### PR DESCRIPTION
- https://github.com/qryxip/rustminify/issues/6
- https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html
- https://doc.rust-jp.rs/edition-guide/rust-2021/reserving-syntax.html
- https://doc.rust-lang.org/reference/tokens.html#reserved-prefixes

minify によって Rust 2021 edition の [`Reserved Prefixes`](https://doc.rust-lang.org/reference/tokens.html#reserved-prefixes) に該当するような出力を生成してしまわないようにするための変更の提案です。

- { [`RAW_IDENTIFIER`](https://doc.rust-lang.org/reference/identifiers.html) (例えば `r#` もしくは `br#` から始まるidentifier) もしくは [`RESERVED_TOKEN_POUND`](https://doc.rust-lang.org/reference/tokens.html#reserved-prefixes) (それ以外の `#` 文字を含む IDENTIFIER) } ( AlnumUnderscoreQuote とは別扱いで、 PoundIdent という分類を作成 ) に対して Punct `#` 文字が後続した場合、空白文字は挿入しません。それ以外の IDENTIFIER (AlnumUnderscoreQuote) に Punct `#` 文字が後続した場合は、空白文字を挿入します。
- 上記ケースを除き、 AlnumUnderscoreQuote に Punct `#` `"` `'` の何れかが後続した場合、空白文字を挿入します。
- minifyによって [`Reserved Prefixes`](https://doc.rust-lang.org/reference/tokens.html#reserved-prefixes) を生成してしまう恐れのあったテストケースを幾つか追加。